### PR TITLE
Update Nginx configuration to correct backend service URL

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -133,7 +133,7 @@ server {
 
     # Backend kimlik doğrulama endpoint'leri (signin, signup)
     location ~ ^/api/auth/(signin|signup|user)(.*)$ {
-        proxy_pass http://spring_backend$request_uri;
+        proxy_pass http://spring-backend:8080$request_uri;
         proxy_cache_bypass $http_upgrade;
         proxy_set_header Authorization $http_authorization;
         proxy_pass_header Authorization;
@@ -193,7 +193,7 @@ server {
 
     # Genel backend API routes
     location /api/ {
-        proxy_pass http://spring_backend/api/;
+        proxy_pass http://spring-backend:8080/;
         proxy_cache_bypass $http_upgrade;
         proxy_set_header Authorization $http_authorization;
         proxy_pass_header Authorization;


### PR DESCRIPTION
- Changed proxy_pass directives in default.conf to use the correct backend service URL format, ensuring proper routing to the Spring backend on port 8080 for authentication and general API requests.